### PR TITLE
[DNM] WIP: add and use date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "private": true,
   "dependencies": {
+    "date-fns": "^1.28.2",
     "moment": "^2.18.1"
   }
 }

--- a/src/ui/components/date-fns-example/component.ts
+++ b/src/ui/components/date-fns-example/component.ts
@@ -1,0 +1,9 @@
+import Component, { tracked } from "@glimmer/component";
+import distanceInWords from "date-fns/distance_in_words";
+
+export default class DateFnsExample extends Component {
+    @tracked since = '';
+    didInsertElement () {
+        this.since = distanceInWords("20111031", new Date());
+    }
+};

--- a/src/ui/components/date-fns-example/template.hbs
+++ b/src/ui/components/date-fns-example/template.hbs
@@ -1,0 +1,1 @@
+<p>date-fns: {{since}}</p>

--- a/src/ui/components/glimmer-npm-deps-example/template.hbs
+++ b/src/ui/components/glimmer-npm-deps-example/template.hbs
@@ -1,4 +1,5 @@
 <div>
   <h1>Welcome to Glimmer!</h1>
   <moment-example />
+  <date-fns-example />
 </div>

--- a/src/ui/components/moment-example/template.hbs
+++ b/src/ui/components/moment-example/template.hbs
@@ -1,1 +1,1 @@
-<p>{{since}}</p>
+<p>moment: {{since}}</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1723,6 +1723,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.2.tgz#19e4192d68875c0bf7c9537e3f296a8ec64853ef"
+
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"


### PR DESCRIPTION
ran `yarn add date-fns` then added a component to import a function from date-fns, but build fails with:

```
glimmer-npm-deps-example git:(date-fns) ✗ ember build
⠋ Building/src/ui/components/date-fns-example/component.ts(2,29): Cannot find module 'date-fns/distance_in_words'.
/src/ui/components/moment-example/component.ts(2,20): Cannot find module 'moment'.
cleaning up...
Build failed.
The Broccoli Plugin: [RollupWithDependencies] failed with:
Error: 'default' is not exported by tmp/rollup_with_dependencies-cache_path-lJJVFqvP.tmp/node_modules/date-fns/distance_in_words/index.js
```